### PR TITLE
add directory to Firefox search plugins paths

### DIFF
--- a/kupfer/plugin/websearch.py
+++ b/kupfer/plugin/websearch.py
@@ -185,6 +185,8 @@ class OpenSearchSource (Source):
 			if os.path.exists(addon_lang_dir):
 				plugin_dirs.append(addon_lang_dir)
 				break
+		if os.path.exists("/usr/lib/firefox/searchplugins"):
+			plugin_dirs.append("/usr/lib/firefox/searchplugins")
 
 		# debian iceweasel
 		if os.path.isdir("/etc/iceweasel/searchplugins/common"):


### PR DESCRIPTION
/usr/lib/firefox/searchplugins can have some more plugins. This used to be /usr/lib/firefox-/searchplugins, but doesn't seem to be any more. I'm not sure when this change happened, but know that it was like that until at least 4.0. Should these be added too?
