### PR TITLE
a Custom Session Management plugin

### DIFF
--- a/kupfer/plugin/session_custom.py
+++ b/kupfer/plugin/session_custom.py
@@ -1,0 +1,60 @@
+__kupfer_name__ = _("Custom Session Management")
+__kupfer_sources__ = ("ItemSource",)
+__description__ = _("Run custom session management commands")
+__version__ = "2"
+__author__ = "Joseph Lansdowne <J49137@gmail.com>"
+
+import shlex
+
+from kupfer.plugin_support import PluginSettings
+from kupfer.plugin import session_support as support
+
+__kupfer_settings__ = PluginSettings(
+	{
+		"key": "logout",
+		"label": _("Log out"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "switchuser",
+		"label": _("Switch user"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "lockscreen",
+		"label": _("Lock screen"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "shutdown",
+		"label": _("Shut down"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "reboot",
+		"label": _("Restart"),
+		"type": str,
+		"value": ""
+	}, {
+		"key": "suspend",
+		"label": _("Suspend"),
+		"type": str,
+		"value": ""
+	}
+)
+
+
+class ItemSource (support.CommonSource):
+
+	def __init__(self):
+		support.CommonSource.__init__(self, _("Custom Session Management"))
+
+	def get_items(self):
+		for item in ("Logout", "SwitchUser", "LockScreen", "Shutdown",
+					 "Reboot", "Suspend"):
+			value = __kupfer_settings__[item.lower()].strip()
+			if value:
+				argv = shlex.split(value)
+				# session_support Leafs take list of argument lists as
+				# fallbacks
+				yield getattr(support, item)((argv,))

--- a/kupfer/plugin/session_gnome.py
+++ b/kupfer/plugin/session_gnome.py
@@ -2,7 +2,7 @@
 __kupfer_name__ = _("GNOME Session Management")
 __kupfer_sources__ = ("GnomeItemsSource", )
 __description__ = _("Special items and actions for GNOME environment")
-__version__ = "2012-10-16"
+__version__ = "2013-4-25"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
 """
@@ -30,8 +30,8 @@ class GnomeItemsSource (support.CommonSource):
 		support.CommonSource.__init__(self, _("GNOME Session Management"))
 	def get_items(self):
 		return (
-			support.Logout(LOGOUT_CMD),
+			support.LogoutBrowse(LOGOUT_CMD),
 			support.LockScreen(LOCKSCREEN_CMD),
-			support.Shutdown(SHUTDOWN_CMD),
+			support.ShutdownBrowse(SHUTDOWN_CMD),
 		)
 

--- a/kupfer/plugin/session_support.py
+++ b/kupfer/plugin/session_support.py
@@ -5,7 +5,7 @@ Common objects for session_* plugins.
 from kupfer.objects import Source, RunnableLeaf
 from kupfer import utils, pretty
 
-__version__ = "2009-12-05"
+__version__ = "2012-09-17"
 __author__ = "Ulrik Sverdrup <ulrik.sverdrup@gmail.com>"
 
 
@@ -20,22 +20,47 @@ def launch_argv_with_fallbacks(commands, print_error=True):
 	pretty.print_error(__name__, "Unable to run command(s)", commands)
 	return False
 
+
 class CommandLeaf (RunnableLeaf):
 	"""The represented object of the CommandLeaf is a list of commandlines"""
 	def run(self):
 		launch_argv_with_fallbacks(self.object)
 
-class Logout (CommandLeaf):
-	"""Log out from desktop"""
+
+class LogoutBrowse (CommandLeaf):
+	"""Log out or switch user"""
 	def __init__(self, commands, name=None):
 		if not name: name = _("Log Out...")
 		CommandLeaf.__init__(self, commands, name)
 	def get_description(self):
-		return _("Log out or change user")
+		return _("Log out or switch user")
 	def get_icon_name(self):
 		return "system-log-out"
 
-class Shutdown (CommandLeaf):
+
+class Logout (CommandLeaf):
+	"""Log out"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Log Out")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Log out")
+	def get_icon_name(self):
+		return "system-log-out"
+
+
+class SwitchUser (CommandLeaf):
+	"""Switch user"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Change User")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Switch to another user")
+	def get_icon_name(self):
+		return "system-switch-user"
+
+
+class ShutdownBrowse (CommandLeaf):
 	"""Shutdown computer or reboot"""
 	def __init__(self, commands, name=None):
 		if not name: name = _("Shut Down...")
@@ -44,6 +69,40 @@ class Shutdown (CommandLeaf):
 		return _("Shut down, restart or suspend computer")
 	def get_icon_name(self):
 		return "system-shutdown"
+
+
+class Shutdown (CommandLeaf):
+	"""Shutdown computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Shut Down")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Shut down computer")
+	def get_icon_name(self):
+		return "system-shutdown"
+
+
+class Reboot (CommandLeaf):
+	"""Reboot computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Restart")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Restart computer")
+	def get_icon_name(self):
+		return "system-reboot"
+
+
+class Suspend (CommandLeaf):
+	"""Suspend computer"""
+	def __init__(self, commands, name=None):
+		if not name: name = _("Suspend")
+		CommandLeaf.__init__(self, commands, name)
+	def get_description(self):
+		return _("Suspend computer")
+	def get_icon_name(self):
+		return "system-suspend"
+
 
 class LockScreen (CommandLeaf):
 	"""Lock screen"""
@@ -54,6 +113,7 @@ class LockScreen (CommandLeaf):
 		return _("Enable screensaver and lock")
 	def get_icon_name(self):
 		return "system-lock-screen"
+
 
 class CommonSource (Source):
 	def __init__(self, name):

--- a/kupfer/plugin/session_xfce.py
+++ b/kupfer/plugin/session_xfce.py
@@ -3,7 +3,7 @@
 __kupfer_name__ = _("XFCE Session Management")
 __kupfer_sources__ = ("XfceItemsSource", )
 __description__ = _("Special items and actions for XFCE environment")
-__version__ = "2009-12-05"
+__version__ = "2012-09-17"
 __author__ = "Karol Będkowski <karol.bedkowski@gmail.com>"
 
 from kupfer.plugin import session_support as support
@@ -20,7 +20,7 @@ class XfceItemsSource (support.CommonSource):
 		support.CommonSource.__init__(self, _("XFCE Session Management"))
 	def get_items(self):
 		return (
-			support.Logout(LOGOUT_CMD),
+			support.LogoutBrowse(LOGOUT_CMD),
 			support.LockScreen(LOCKSCREEN_CMD),
-			support.Shutdown(SHUTDOWN_CMD),
+			support.ShutdownBrowse(SHUTDOWN_CMD),
 		)


### PR DESCRIPTION
Adds a text entry for each command in the plugin preferences (not very aligned, though - is there a way to fix that?).

The Gnome/Xfce plugins launch a dialogue for log out/shut down with with further options, so this commit renames the classes in session_support for these and creates extra classes for each individual command they each cover. (That is, log out covers log out and switch user, and shut down covers shut down, reboot and suspend.)

The system-switch-user and system-suspend icons don't seem to be in the freedesktop icon naming spec, but I have them on my machine - should they be changed?

The obvious thing to do to disable any of these is to empty the text box, but for some reason Kupfer doesn't save blank text entries (see `kupfer.ui.preferences.PreferencesWindowController._make_plugin_settings_widget`).
